### PR TITLE
Add metrics card to YouTube stats and publish artifacts

### DIFF
--- a/.github/workflows/youtube-metrics.yml
+++ b/.github/workflows/youtube-metrics.yml
@@ -40,3 +40,19 @@ jobs:
           else
             echo "No changes to commit."
           fi
+
+      - name: Publish metrics to docs (copy artifacts)
+        run: |
+          mkdir -p docs/metrics
+          cp -f data/metrics/youtube_enriched.csv docs/metrics/youtube_enriched.csv || true
+          cp -f data/metrics/youtube_summary.json docs/metrics/youtube_summary.json || true
+
+      - name: Commit published artifacts (if any)
+        run: |
+          git add docs/metrics/youtube_enriched.csv docs/metrics/youtube_summary.json || true
+          if ! git diff --cached --quiet; then
+            git commit -m "📤 Publish metrics artifacts to docs/"
+            git push
+          else
+            echo "No changes to publish."
+          fi

--- a/docs/index.html
+++ b/docs/index.html
@@ -212,5 +212,9 @@ async function drawChart() {
 drawChart();
   </script>
 
+  <!-- Metrics Card (safe, additive) -->
+  <script src="/automated/js/yt-metrics-card.js"></script>
+  <script src="/js/yt-metrics-card.js"></script>
+
 </body>
 </html>

--- a/docs/js/yt-metrics-card.js
+++ b/docs/js/yt-metrics-card.js
@@ -1,0 +1,117 @@
+(async function () {
+  const SUMMARY_URL = '/automated/metrics/youtube_summary.json'
+    .replace('/automated/', (location.pathname.includes('/automated') ? '/automated/' : '/'));
+  // Graceful: try both with and without /automated prefix
+  const tryUrls = [
+    SUMMARY_URL,
+    '/metrics/youtube_summary.json'
+  ];
+
+  function el(tag, attrs = {}, children = []) {
+    const node = document.createElement(tag);
+    Object.entries(attrs).forEach(([k, v]) => {
+      if (k === 'class') node.className = v;
+      else if (k.startsWith('on') && typeof v === 'function') node[k] = v;
+      else node.setAttribute(k, v);
+    });
+    [].concat(children).forEach(c => node.appendChild(typeof c === 'string' ? document.createTextNode(c) : c));
+    return node;
+  }
+
+  function fmt(n, digits = 0) {
+    if (n == null || Number.isNaN(n)) return '—';
+    return Number(n).toLocaleString(undefined, { maximumFractionDigits: digits, minimumFractionDigits: digits });
+  }
+
+  async function fetchSummary() {
+    let lastErr;
+    for (const u of tryUrls) {
+      try {
+        const res = await fetch(u, { cache: 'no-store' });
+        if (res.ok) return res.json();
+        lastErr = new Error(`HTTP ${res.status}`);
+      } catch (e) { lastErr = e; }
+    }
+    throw lastErr || new Error('Unable to load metrics summary');
+  }
+
+  function renderCard(s) {
+    const proj = s.projection || {};
+    const roll = s.rolling || {};
+    const ratios = s.ratios || {};
+
+    const pill = (label, value) =>
+      el('div', { class: 'im-pill' }, [
+        el('span', { class: 'im-pill-label' }, label),
+        el('span', { class: 'im-pill-value' }, value)
+      ]);
+
+    const etaText = (obj) => {
+      if (!obj || obj.eta_days == null) return '—';
+      return `${fmt(obj.eta_days, 1)}d (${new Date(obj.eta_date).toUTCString().replace(' GMT', '')})`;
+    };
+
+    const root = el('section', { class: 'im-card' }, [
+      el('h3', { class: 'im-title' }, 'Metrics'),
+      el('div', { class: 'im-row' }, [
+        pill('Subs/day (7d)', fmt(roll.subs_per_day_7, 2)),
+        pill('Subs/day (30d)', fmt(roll.subs_per_day_30, 2)),
+        pill('Views/day (7d)', fmt(roll.views_per_day_7, 0)),
+        pill('Views/day (30d)', fmt(roll.views_per_day_30, 0)),
+      ]),
+      el('div', { class: 'im-row' }, [
+        pill('Views/Video', fmt(ratios.views_per_video, 0)),
+        pill('Views/Sub', fmt(ratios.views_per_sub, 0)),
+        pill('Subs/Video', fmt(ratios.subs_per_video, 2)),
+      ]),
+      el('div', { class: 'im-row' }, [
+        pill(`ETA ${proj.next_50?.target || 'next 50'}`, etaText(proj.next_50)),
+        pill(`ETA ${proj.next_100?.target || 'next 100'}`, etaText(proj.next_100)),
+        pill('ETA 1000', etaText(proj.to_1000)),
+      ]),
+      el('div', { class: 'im-foot' }, [
+        el('span', { class: 'im-muted' }, `Last updated: ${new Date(s.last_updated).toUTCString().replace(' GMT','')}`)
+      ])
+    ]);
+
+    // Attach near the existing chart if possible
+    const anchors = [
+      document.querySelector('#youtube-chart'),
+      document.querySelector('#chart'),
+      document.querySelector('.chart-container'),
+      document.querySelector('main'),
+      document.body
+    ].filter(Boolean);
+
+    const anchor = anchors[0] || document.body;
+    anchor.parentNode.insertBefore(root, anchor.nextSibling);
+  }
+
+  // Inject minimal styles (scoped names)
+  const css = `
+  .im-card{margin:20px auto;max-width:1100px;background:#fff;border-radius:16px;padding:16px 18px;box-shadow:0 8px 24px rgba(0,0,0,.06)}
+  @media (prefers-color-scheme: dark){
+    .im-card{background:#111;border:1px solid rgba(255,255,255,.08)}
+    .im-pill{background:rgba(255,255,255,.06)}
+    .im-title{color:#fff}
+    .im-muted{color:#aaa}
+  }
+  .im-title{margin:0 0 8px;font-size:1.1rem}
+  .im-row{display:flex;flex-wrap:wrap;gap:8px;margin:8px 0}
+  .im-pill{display:flex;gap:6px;align-items:center;padding:8px 10px;border-radius:999px;background:#f5f7fb}
+  .im-pill-label{font-size:.85rem;opacity:.8}
+  .im-pill-value{font-weight:600}
+  .im-foot{margin-top:6px}
+  .im-muted{font-size:.85rem;opacity:.7}
+  `;
+  const style = el('style', {}, css);
+  document.head.appendChild(style);
+
+  try {
+    const summary = await fetchSummary();
+    if (summary && summary.current) renderCard(summary);
+  } catch (e) {
+    // Silent fail to avoid breaking the page
+    console.debug('Metrics card unavailable:', e?.message || e);
+  }
+})();


### PR DESCRIPTION
## Summary
- publish derived YouTube metrics artifacts to `docs/metrics/` for web serving
- embed a lightweight metrics card loader on the YouTube stats page
- include tiny frontend module that fetches metrics summary and renders rolling growth, ratios and ETA badges

## Testing
- `python -m py_compile scripts/yt_metrics.py`
- `node --check docs/js/yt-metrics-card.js`


------
https://chatgpt.com/codex/tasks/task_e_68a26bb4c65c832999574e0134d5f5f5