### PR TITLE
style: add stats layout and MA toggle

### DIFF
--- a/docs/css/stats.css
+++ b/docs/css/stats.css
@@ -1,0 +1,29 @@
+/* Site tokens */
+:root{
+  --bg:#f5f7fa;
+  --fg:#111;
+  --muted:#6b7280;
+  --card-bg:#fff;
+  --card-fg:#111;
+  --pill-bg:#f1f3f5;
+  --pill-fg:#111;
+  --border:rgba(0,0,0,.08);
+  --shadow:0 8px 24px rgba(0,0,0,.06);
+}
+
+/* Force light look for cards regardless of OS dark mode */
+html,body{background:var(--bg)}
+body{color:var(--fg); color-scheme: light;}
+
+/* Layout helpers */
+.container{max-width:1100px;margin:0 auto;}
+.section{background:var(--card-bg);color:var(--card-fg);border-radius:16px;box-shadow:var(--shadow);padding:16px 18px;margin:20px auto}
+
+/* Override styles injected by JS components */
+.im-card,.yt-eta-card{background:var(--card-bg)!important;color:var(--card-fg)!important;border:1px solid var(--border)!important}
+.im-title{color:var(--card-fg)!important}
+.im-pill,.yt-eta-items span{background:var(--pill-bg)!important;color:var(--pill-fg)!important;border:1px solid var(--border)!important}
+.im-muted{color:var(--muted)!important}
+
+/* Nice table framing on wide screens */
+#statsTable{border-radius:12px;overflow:hidden}

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,6 +3,7 @@
 <head>
   <title>YouTube Stats Viewer</title>
   <meta charset="UTF-8" />
+  <link rel="stylesheet" href="css/stats.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <style>
     body {
@@ -46,9 +47,16 @@
   </style>
 </head>
 <body>
+<div class="container">
   <h1>YouTube Stats</h1>
 
   <!-- Chart canvas -->
+  <div class="section" style="display:flex;align-items:center;gap:12px;margin-top:0">
+    <label style="display:flex;align-items:center;gap:8px">
+      <input type="checkbox" id="maToggle" checked>
+      <span>Show 7‑day averages</span>
+    </label>
+  </div>
   <canvas id="growthChart" width="600" height="300"></canvas>
 
   <!-- Stats table -->
@@ -220,5 +228,33 @@ drawChart();
   <script src="/automated/js/yt-overlays.js"></script>
   <script src="/js/yt-overlays.js"></script>
 
+  <script>
+    // If ytChart and overlays are present, allow toggling the two averaged datasets
+    (function(){
+      const cb = document.getElementById('maToggle');
+      if (!cb) return;
+      const findAvgIdx = () => {
+        const c = window.ytChart;
+        if (!c) return [];
+        const isAvg = d => /7-day avg/i.test(d.label||'');
+        const idx = [];
+        c.data.datasets.forEach((d,i)=>{ if(isAvg(d)) idx.push(i); });
+        return idx;
+      };
+      cb.addEventListener('change', () => {
+        const c = window.ytChart; if (!c) return;
+        const idx = findAvgIdx();
+        idx.forEach(i => { c.getDatasetMeta(i).hidden = !cb.checked; });
+        c.update('none');
+      });
+      // If datasets were added after load, auto-enable
+      const iv = setInterval(() => {
+        if (findAvgIdx().length){ cb.dispatchEvent(new Event('change')); clearInterval(iv); }
+      }, 500);
+      setTimeout(()=>clearInterval(iv), 5000);
+    })();
+  </script>
+
+</div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add stats.css to enforce light card theme and layout
- link stylesheet, wrap content, and add 7-day average toggle for chart
- allow toggling averaged datasets via small JS helper

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4da58c1e483298fc7e0dfdbe33ce4