### PR TITLE
Add 7-day average datasets and shorten chart dates

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -121,31 +121,35 @@
   <!-- Chart JS -->
   <script>
 async function fetchData() {
-  const text = await (await fetch('youtube/youtube-history-summed.csv')).text();
+  const text = await (await fetch('metrics/youtube_enriched.csv')).text();
   const rows = text.trim().split('\n');
-  const headers = rows.shift().split(',');
+  rows.shift(); // drop header
 
   const labels = [];
   const subsData = [];
   const vidsData = [];
   const viewsData = [];
+  const subsAvg = [];
+  const viewsAvg = [];
 
   rows.forEach(row => {
-    if (!row.trim()) return; // Skip empty lines
-
-    const [date, subscribers, videos, views] = row.split(',');
-
-    labels.push(date);
-    subsData.push(Number(subscribers));
-    vidsData.push(Number(videos));
+    if (!row.trim()) return;
+    const parts = row.split(',');
+    const [date, subs, vids, views, , , , subs7, views7] = parts;
+    const d = new Date(date);
+    labels.push(d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }));
+    subsData.push(Number(subs));
+    vidsData.push(Number(vids));
     viewsData.push(Number(views));
+    subsAvg.push(subs7 === '' ? null : Number(subs7));
+    viewsAvg.push(views7 === '' ? null : Number(views7));
   });
 
-  return { labels, subsData, vidsData, viewsData };
+  return { labels, subsData, vidsData, viewsData, subsAvg, viewsAvg };
 }
 
 async function drawChart() {
-  const { labels, subsData, vidsData, viewsData } = await fetchData();
+  const { labels, subsData, vidsData, viewsData, subsAvg, viewsAvg } = await fetchData();
 
   const ctx = document.getElementById('growthChart').getContext('2d');
   const chart = new Chart(ctx, {
@@ -179,6 +183,26 @@ async function drawChart() {
           tension: 0.3,
           pointRadius: 4,
           yAxisID: 'y_views'
+        },
+        {
+          label: 'Subs (7-day avg)',
+          data: subsAvg,
+          borderColor: '#1e90ff',
+          borderDash: [6,6],
+          pointRadius: 0,
+          tension: 0.2,
+          yAxisID: 'y_subs_avg',
+          fill: false
+        },
+        {
+          label: 'Views (7-day avg)',
+          data: viewsAvg,
+          borderColor: '#32cd32',
+          borderDash: [6,6],
+          pointRadius: 0,
+          tension: 0.2,
+          yAxisID: 'y_views_avg',
+          fill: false
         }
       ]
     },
@@ -206,7 +230,31 @@ async function drawChart() {
           beginAtZero: false,
           grid: { drawOnChartArea: false }
         },
-        x: { title: { display: true, text: 'Date' } }
+        y_subs_avg: {
+          type: 'linear',
+          position: 'left',
+          display: true,
+          grid: { drawOnChartArea: false },
+          ticks: { stepSize: 1 },
+          min: 0,
+          suggestedMax: 3,
+          title: { display: false }
+        },
+        y_views_avg: {
+          type: 'linear',
+          position: 'right',
+          display: true,
+          offset: true,
+          grid: { drawOnChartArea: false },
+          ticks: { stepSize: 500 },
+          min: 0,
+          suggestedMax: 3000,
+          title: { display: false }
+        },
+        x: {
+          title: { display: true, text: 'Date' },
+          ticks: { maxRotation: 0, autoSkip: true, maxTicksLimit: 15 }
+        }
       },
       plugins: {
         title: { display: true, text: 'YouTube Channel Combined Growth Over Time' },
@@ -247,11 +295,7 @@ drawChart();
         idx.forEach(i => { c.getDatasetMeta(i).hidden = !cb.checked; });
         c.update('none');
       });
-      // If datasets were added after load, auto-enable
-      const iv = setInterval(() => {
-        if (findAvgIdx().length){ cb.dispatchEvent(new Event('change')); clearInterval(iv); }
-      }, 500);
-      setTimeout(()=>clearInterval(iv), 5000);
+      cb.dispatchEvent(new Event('change'));
     })();
   </script>
 

--- a/docs/js/yt-overlays.js
+++ b/docs/js/yt-overlays.js
@@ -28,53 +28,56 @@
   const chart = await until(()=>window.ytChart);
   if (!chart) { console.debug('yt-overlays: chart not found'); return; }
 
-  // Add moving-average overlays (if CSV exists)
-  try {
-    const csv = await getText(csvUrls);
-    const df  = parseCSV(csv);
-    if (df && df.length) {
-      const labels   = df.map(r => new Date(r.date).toISOString());
-      const subsAvg7 = df.map(r => (r.subs_day_avg_7===''?null:+r.subs_day_avg_7));
-      const viewsAvg7= df.map(r => (r.views_day_avg_7===''?null:+r.views_day_avg_7));
+  // Add moving-average overlays (if CSV exists and not already provided)
+  const hasAvg = chart.data.datasets.some(d => /7-day avg/i.test(d.label||''));
+  if (!hasAvg) {
+    try {
+      const csv = await getText(csvUrls);
+      const df  = parseCSV(csv);
+      if (df && df.length) {
+        const labels   = df.map(r => new Date(r.date).toISOString());
+        const subsAvg7 = df.map(r => (r.subs_day_avg_7===''?null:+r.subs_day_avg_7));
+        const viewsAvg7= df.map(r => (r.views_day_avg_7===''?null:+r.views_day_avg_7));
 
-      // Ensure labels cover entire series if needed
-      if (chart.data.labels.length < labels.length) chart.data.labels = labels;
+        // Ensure labels cover entire series if needed
+        if (chart.data.labels.length < labels.length) chart.data.labels = labels;
 
-      const subsColor  = (chart.data.datasets[0]?.borderColor) || 'rgba(30,144,255,.8)';
-      const viewsColor = (chart.data.datasets.find(d=>d.yAxisID==='y_views')?.borderColor) || 'rgba(50,205,50,.8)';
+        const subsColor  = (chart.data.datasets[0]?.borderColor) || 'rgba(30,144,255,.8)';
+        const viewsColor = (chart.data.datasets.find(d=>d.yAxisID==='y_views')?.borderColor) || 'rgba(50,205,50,.8)';
 
-      // Add compact axes for moving averages if not present
-      chart.options.scales = chart.options.scales || {};
-      chart.options.scales.y_subs_avg = chart.options.scales.y_subs_avg || {
-        type: 'linear',
-        position: 'left',
-        display: true,
-        grid: { drawOnChartArea: false },
-        ticks: { stepSize: 1 },
-        min: 0,
-        suggestedMax: 3,
-        title: { display: false }
-      };
-      chart.options.scales.y_views_avg = chart.options.scales.y_views_avg || {
-        type: 'linear',
-        position: 'right',
-        display: true,
-        offset: true,
-        grid: { drawOnChartArea: false },
-        ticks: { stepSize: 500 },
-        min: 0,
-        suggestedMax: 3000,
-        title: { display: false }
-      };
+        // Add compact axes for moving averages if not present
+        chart.options.scales = chart.options.scales || {};
+        chart.options.scales.y_subs_avg = chart.options.scales.y_subs_avg || {
+          type: 'linear',
+          position: 'left',
+          display: true,
+          grid: { drawOnChartArea: false },
+          ticks: { stepSize: 1 },
+          min: 0,
+          suggestedMax: 3,
+          title: { display: false }
+        };
+        chart.options.scales.y_views_avg = chart.options.scales.y_views_avg || {
+          type: 'linear',
+          position: 'right',
+          display: true,
+          offset: true,
+          grid: { drawOnChartArea: false },
+          ticks: { stepSize: 500 },
+          min: 0,
+          suggestedMax: 3000,
+          title: { display: false }
+        };
 
-      chart.data.datasets.push(
-        { label:'Subs (7-day avg)',  data:subsAvg7,  yAxisID:'y_subs_avg',  borderWidth:1, borderDash:[6,6], pointRadius:0, tension:.2, borderColor:subsColor,  fill:false },
-        { label:'Views (7-day avg)', data:viewsAvg7, yAxisID:'y_views_avg', borderWidth:1, borderDash:[6,6], pointRadius:0, tension:.2, borderColor:viewsColor, fill:false }
-      );
-      chart.update('none');
+        chart.data.datasets.push(
+          { label:'Subs (7-day avg)',  data:subsAvg7,  yAxisID:'y_subs_avg',  borderWidth:1, borderDash:[6,6], pointRadius:0, tension:.2, borderColor:subsColor,  fill:false },
+          { label:'Views (7-day avg)', data:viewsAvg7, yAxisID:'y_views_avg', borderWidth:1, borderDash:[6,6], pointRadius:0, tension:.2, borderColor:viewsColor, fill:false }
+        );
+        chart.update('none');
+      }
+    } catch (e) {
+      console.debug('yt-overlays: enriched CSV unavailable (ok):', e?.message || e);
     }
-  } catch (e) {
-    console.debug('yt-overlays: enriched CSV unavailable (ok):', e?.message || e);
   }
 
   // Add “Next Milestones” badge (if JSON exists)


### PR DESCRIPTION
## Summary
- Render 7-day average subscriber and view trends directly in the main chart
- Use shorter "MMM D" date labels with fewer x-axis ticks for readability
- Prevent overlay script from re-adding moving average lines if already present

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e07612348329aa5b3f1937c760e9