### PR TITLE
feat: modernize analytics layout

### DIFF
--- a/docs/css/modern-stats.css
+++ b/docs/css/modern-stats.css
@@ -1,0 +1,40 @@
+/* Design tokens */
+:root{
+  --bg:#f6f8fb;
+  --fg:#0f172a;
+  --muted:#6b7280;
+  --card:#ffffff;
+  --border:rgba(15,23,42,.08);
+  --shadow:0 10px 30px rgba(2,6,23,.06);
+  --pill:#f1f5f9;
+  --radius:16px;
+  --gap:16px;
+  --container:1100px;
+}
+
+html,body{background:var(--bg);color:var(--fg);font-family:ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial}
+.container{max-width:var(--container);margin:0 auto;padding:0 12px}
+
+/* Cards */
+.card{background:var(--card);border:1px solid var(--border);border-radius:var(--radius);box-shadow:var(--shadow);padding:16px 18px}
+.card h3{margin:0 0 10px;font-size:1.05rem}
+.stack>*+*{margin-top:var(--gap)} /* vertical rhythm */
+
+/* Grid for analytics cards (responsive) */
+.grid-2{display:grid;grid-template-columns:1fr 1fr;gap:var(--gap)}
+@media (max-width: 900px){ .grid-2{grid-template-columns:1fr} }
+
+/* Table polish */
+#statsTable{border-radius:12px;overflow:hidden}
+#statsTable thead th{background:#f1f5f9}
+#statsTable tbody tr:last-child{background:#edf6ff;font-weight:700}
+
+/* Pills used by both cards */
+.pills{display:flex;flex-wrap:wrap;gap:10px}
+.pill{display:flex;align-items:center;gap:8px;padding:8px 12px;border-radius:999px;background:var(--pill);border:1px solid var(--border)}
+.pill .label{opacity:.7;font-size:.9rem}
+.pill .value{font-weight:700}
+
+/* Slots (mount points) keep spacing consistent */
+.section{padding:0} /* the chart/table already sit in cards */
+.controls{display:flex;align-items:center;gap:10px}

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,6 +4,7 @@
   <title>YouTube Stats Viewer</title>
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="css/stats.css">
+  <link rel="stylesheet" href="css/modern-stats.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <style>
     body {
@@ -47,20 +48,31 @@
   </style>
 </head>
 <body>
-<div class="container">
+<div class="container stack">
   <h1>YouTube Stats</h1>
-
-  <!-- Chart canvas -->
-  <div class="section" style="display:flex;align-items:center;gap:12px;margin-top:0">
-    <label style="display:flex;align-items:center;gap:8px">
-      <input type="checkbox" id="maToggle" checked>
-      <span>Show 7‑day averages</span>
-    </label>
+  <div class="card section">
+    <div class="controls">
+      <label style="display:flex;align-items:center;gap:8px">
+        <input type="checkbox" id="maToggle" checked> <span>Show 7‑day averages</span>
+      </label>
+    </div>
   </div>
-  <canvas id="growthChart" width="600" height="300"></canvas>
 
-  <!-- Stats table -->
-  <table id="statsTable">
+  <div class="card section" id="chartCard">
+    <canvas id="growthChart" width="600" height="300"></canvas>
+  </div>
+
+  <div class="grid-2 section" id="analyticsGrid">
+    <div class="card" id="milestonesMount">
+      <!-- Will be replaced by Next Milestones JS; left here as a slot -->
+    </div>
+    <div class="card" id="metricsMount">
+      <!-- Will be replaced by Metrics Card JS; left here as a slot -->
+    </div>
+  </div>
+
+  <div class="card section" id="tableCard">
+    <table id="statsTable">
     <thead>
       <tr>
         <th>Channel</th>
@@ -74,6 +86,7 @@
       <tr><td colspan="5">Loading...</td></tr>
     </tbody>
   </table>
+  </div>
 
   <!-- Table JS -->
   <script>

--- a/docs/js/yt-metrics-card.js
+++ b/docs/js/yt-metrics-card.js
@@ -76,6 +76,8 @@
 
     // Attach near the existing chart if possible
     const anchors = [
+      document.querySelector('#metricsMount'),
+      document.querySelector('#chartCard'),
       document.querySelector('#youtube-chart'),
       document.querySelector('#chart'),
       document.querySelector('.chart-container'),
@@ -84,12 +86,16 @@
     ].filter(Boolean);
 
     const anchor = anchors[0] || document.body;
-    anchor.parentNode.insertBefore(root, anchor.nextSibling);
+    if (anchor.id === 'metricsMount') {
+      anchor.replaceWith(root);
+    } else {
+      anchor.parentNode.insertBefore(root, anchor.nextSibling);
+    }
   }
 
   // Inject minimal styles (scoped names)
   const css = `
-.im-card{margin:20px auto;max-width:1100px;background:#fff;border-radius:16px;padding:18px 20px;box-shadow:0 8px 24px rgba(0,0,0,.06);color:#111}
+.im-card{margin:0;background:#fff;border-radius:16px;padding:16px 18px;box-shadow:0 8px 24px rgba(0,0,0,.06);color:#111}
 @media (prefers-color-scheme: dark){
   .im-card{background:#141417;border:1px solid rgba(255,255,255,.08);color:#eaeaea}
   .im-pill{background:rgba(255,255,255,.08);color:#eaeaea}

--- a/docs/js/yt-overlays.js
+++ b/docs/js/yt-overlays.js
@@ -83,7 +83,7 @@
   // Add “Next Milestones” badge (if JSON exists)
   try {
     const s = await getJSON(jsonUrls);
-    const p = s?.projection || {};
+    const proj = s?.projection || {};
     const toText = (o)=>!o||o.eta_days==null ? '—' : `${o.target}: ${o.eta_days.toFixed(1)}d (${new Date(o.eta_date).toUTCString().replace(' GMT','')})`;
 
     const wrap = document.createElement('div');
@@ -91,27 +91,22 @@
     wrap.innerHTML = `
       <div class="yt-eta-card">
         <div class="yt-eta-title">Next Milestones</div>
-        <div class="yt-eta-items">
-          <span>${toText(p.next_50)}</span>
-          <span>${toText(p.next_100)}</span>
-          <span>${toText(p.to_1000)}</span>
+        <div class="yt-eta-items pills">
+          <span class="pill"><span class="value">${toText(proj.next_50)}</span></span>
+          <span class="pill"><span class="value">${toText(proj.next_100)}</span></span>
+          <span class="pill"><span class="value">${toText(proj.to_1000)}</span></span>
         </div>
       </div>`;
-    const css = document.createElement('style');
-    css.textContent = `
-  .yt-eta{max-width:1100px;margin:12px auto 20px}
-  .yt-eta-card{border-radius:12px;padding:12px 14px;background:#fff;box-shadow:0 6px 18px rgba(0,0,0,.05);color:#111}
-  .yt-eta-title{font-weight:700;margin-bottom:6px}
-  .yt-eta-items{display:flex;flex-wrap:wrap;gap:10px}
-  .yt-eta-items span{padding:6px 10px;border-radius:999px;background:#f1f3f5;border:1px solid rgba(0,0,0,.06)}
-  @media (prefers-color-scheme: dark){
-    .yt-eta-card{background:#141417;border:1px solid rgba(255,255,255,.08);color:#eaeaea}
-    .yt-eta-items span{background:rgba(255,255,255,.08);border-color:rgba(255,255,255,.08)}
-  }`;
-    document.head.appendChild(css);
+    const style = document.createElement('style');
+    style.textContent = `
+  .yt-eta-card{background:transparent;border:0;padding:0}
+  .yt-eta-title{font-weight:700;margin-bottom:8px}
+`;
+    document.head.appendChild(style);
 
-    const anchor = document.querySelector('#growthChart')?.parentElement || document.querySelector('main') || document.body;
-    anchor.appendChild(wrap);
+    const slot = document.querySelector('#milestonesMount') || document.querySelector('#chartCard') || document.body;
+    slot.innerHTML = '';
+    slot.appendChild(wrap);
   } catch (e) {
     console.debug('yt-overlays: summary JSON unavailable (ok):', e?.message || e);
   }


### PR DESCRIPTION
## Summary
- add modern stats stylesheet and layout wrappers
- align metrics and milestones cards with slot-based mounting
- adjust metrics card and overlays scripts for new slots

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4f35cbe888329a47357739d0e3d90