### PR TITLE
chore: remove timestamps from milestone and metric dates

### DIFF
--- a/docs/js/yt-metrics-card.js
+++ b/docs/js/yt-metrics-card.js
@@ -23,6 +23,16 @@
     return Number(n).toLocaleString(undefined, { maximumFractionDigits: digits, minimumFractionDigits: digits });
   }
 
+  function fmtDate(d) {
+    return new Date(d).toLocaleDateString('en-US', {
+      weekday: 'short',
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      timeZone: 'UTC'
+    });
+  }
+
   async function fetchSummary() {
     let lastErr;
     for (const u of tryUrls) {
@@ -48,7 +58,7 @@
 
     const etaText = (obj) => {
       if (!obj || obj.eta_days == null) return '—';
-      return `${fmt(obj.eta_days, 1)}d (${new Date(obj.eta_date).toUTCString().replace(' GMT', '')})`;
+      return `${fmt(obj.eta_days, 1)}d (${fmtDate(obj.eta_date)})`;
     };
 
     const root = el('section', { class: 'im-card' }, [
@@ -70,7 +80,7 @@
         pill('ETA 1000', etaText(proj.to_1000)),
       ]),
       el('div', { class: 'im-foot' }, [
-        el('span', { class: 'im-muted' }, `Last updated: ${new Date(s.last_updated).toUTCString().replace(' GMT','')}`)
+        el('span', { class: 'im-muted' }, `Last updated: ${fmtDate(s.last_updated)}`)
       ])
     ]);
 

--- a/docs/js/yt-overlays.js
+++ b/docs/js/yt-overlays.js
@@ -84,7 +84,14 @@
   try {
     const s = await getJSON(jsonUrls);
     const proj = s?.projection || {};
-    const toText = (o)=>!o||o.eta_days==null ? '—' : `${o.target}: ${o.eta_days.toFixed(1)}d (${new Date(o.eta_date).toUTCString().replace(' GMT','')})`;
+    const fmtDate = (d) => new Date(d).toLocaleDateString('en-US', {
+      weekday: 'short',
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      timeZone: 'UTC'
+    });
+    const toText = (o)=>!o||o.eta_days==null ? '—' : `${o.target}: ${o.eta_days.toFixed(1)}d (${fmtDate(o.eta_date)})`;
 
     const wrap = document.createElement('div');
     wrap.className = 'yt-eta';


### PR DESCRIPTION
## Summary
- show only dates in milestone projections
- display date-only strings for metrics ETA and last updated

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a50af84fbc83298789537cf3d8775c