### PR TITLE
feat: start growth chart axis near data minimum

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -164,6 +164,11 @@ async function fetchData() {
 async function drawChart() {
   const { labels, subsData, vidsData, viewsData, subsAvg, viewsAvg } = await fetchData();
 
+  // Determine minimum values for each main dataset so axes don't start at zero
+  const subsMin  = Math.min(...subsData);
+  const vidsMin  = Math.min(...vidsData);
+  const viewsMin = Math.min(...viewsData);
+
   const ctx = document.getElementById('growthChart').getContext('2d');
   const chart = new Chart(ctx, {
     type: 'line',
@@ -226,13 +231,15 @@ async function drawChart() {
           type: 'linear',
           position: 'left',
           title: { display: true, text: 'Subscribers' },
-          beginAtZero: false
+          beginAtZero: false,
+          suggestedMin: subsMin
         },
         y_vids: {
           type: 'linear',
           position: 'right',
           title: { display: true, text: 'Videos' },
           beginAtZero: false,
+          suggestedMin: vidsMin,
           grid: { drawOnChartArea: false }
         },
         y_views: {
@@ -241,6 +248,7 @@ async function drawChart() {
           offset: true,
           title: { display: true, text: 'Views' },
           beginAtZero: false,
+          suggestedMin: viewsMin,
           grid: { drawOnChartArea: false }
         },
         y_subs_avg: {


### PR DESCRIPTION
## Summary
- derive minimum values for each dataset and use them to suggest the y-axis start
- update growth chart scales so axes no longer default to zero

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a72d188df083298d79aeec76455213